### PR TITLE
expanding the div for 1.7.2 was not possible

### DIFF
--- a/Website/Views/changelog.cshtml
+++ b/Website/Views/changelog.cshtml
@@ -670,12 +670,12 @@
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         <h4 class="panel-title">
-                            <a data-toggle="collapse" data-parent="#accordion2013" href="#cl_vs13_172">
+                            <a data-toggle="collapse" data-parent="#accordion2013" href="#cl_vs13_18">
                                 1.8 - January 30, 2014
                             </a>
                         </h4>
                     </div>
-                    <div id="cl_vs13_172" class="panel-collapse in">
+                    <div id="cl_vs13_18" class="panel-collapse in">
                         <div class="panel-body">
                             <ul>
                                 <li>JSCS - StyleCop for JavaScript added</li>


### PR DESCRIPTION
... due to duplicate IDs. Didn't WebEssentials catch that ;-)
