### PR TITLE
Update Bootstrap columns validator text

### DIFF
--- a/Website/Views/features/html.cshtml
+++ b/Website/Views/features/html.cshtml
@@ -233,7 +233,7 @@
                 <h3 class="panel-heading">Bootstrap columns validator</h3>
                 <div class="panel-body">
                     <p>
-                        Bootstrap includes a grid system that can scales up to 12 columns. This validator 
+                        Bootstrap includes a grid system that can scale up to 12 columns. This validator 
                         makes sure that you don’t exceed this maximum for each size of columns you define.
                         It also checks for the presence of the required Bootstrap <code>row</code>
                         class on a parent element of your column declarations.


### PR DESCRIPTION
New text based on the new behavior: display an error only if more than 12 columns
