### PR TITLE
Routing: Add GoToFeature system

### DIFF
--- a/Website/GoTo.ashx
+++ b/Website/GoTo.ashx
@@ -1,0 +1,37 @@
+﻿<%@ WebHandler Language="C#" Class="GoTo" %>
+
+using System.Web;
+
+public class GoTo : IHttpHandler
+{
+    public void ProcessRequest(HttpContext context)
+    {
+        string requestedFeature = string.Empty;
+
+        if (context.Request.QueryString.Count > 0 && context.Request.QueryString["id"] != null)
+        {
+            requestedFeature = context.Request.QueryString["id"];
+        }
+
+        switch (requestedFeature)
+        {
+            case "weignore":
+                context.Response.Redirect("/features/general#weignore");
+                break;
+
+            default:
+                // Not found... return to homepage
+                context.Response.Redirect("/");
+                break;
+        }
+    }
+
+    public bool IsReusable
+    {
+        get
+        {
+            return false;
+        }
+    }
+
+}

--- a/Website/Web.config
+++ b/Website/Web.config
@@ -56,6 +56,10 @@
           <match url="^nightly/2013/?$"/>
           <action type="Rewrite" url="/nightly/feed/feed.ashx"/>
         </rule>
+        <rule name="goTo" stopProcessing="false">
+          <match url="^goto/([_0-9a-z-]+)" ignoreCase="true" negate="false"/>
+          <action type="Rewrite" url="GoTo.ashx?id={R:1}" />
+        </rule>
       </rules>
     </rewrite>
   </system.webServer>


### PR DESCRIPTION
A permalink feature that can be useful when writing hyperlink about WebEssentials documentation on others project (as on .weignore template file inline documentation for ligershark/side-waffle#145 ) or web sites.

This could allow the WE web site documentation to be refactored without impacting too much external links in the future.

Per example: http://vswebessentials.com/goto/weignore will redirect to http://vswebessentials.com/features/general#weignore for now. But, as there so much that can be explained about this file that maybe it will deserve a complete page in the future.

This is a proposition, feel free to challenge the way I implemented it.
