### PR TITLE
ChangeLog: Fix missing release name

### DIFF
--- a/Website/App_Code/ChangeLogHelper.cs
+++ b/Website/App_Code/ChangeLogHelper.cs
@@ -101,7 +101,15 @@ public class ChangeLogHelper
                 {
                     publishedAt = r.PublishedAt.Value.Date.ToString("MMM dd. yyyy");
                 }
-                s.AppendFormat("{0} <em style=\"float:right;margin-right:6em\">{1}</em>", r.Name, publishedAt);
+
+                string releaseName = r.Name;
+                // At least will display tagName (usually release version)
+                if (string.IsNullOrWhiteSpace(r.Name))
+                {
+                    releaseName = r.TagName;
+                }
+
+                s.AppendFormat("{0} <em style=\"float:right;margin-right:6em\">{1}</em>", releaseName, publishedAt);
                 s.AppendFormat("<a class='btn btn-success btn-nightly-download' href='{0}'><i class='fa fa-download'></i>Download</a>", r.HtmlUrl);
                 s.Append("</a></h4></div>");
                 var collapseClass = i == 0 ? "in" : "collapse";


### PR DESCRIPTION
Last release for WE2013 only contains TagName, not a name.

Before:
![image](https://cloud.githubusercontent.com/assets/1680372/8754143/5ac224da-2c8f-11e5-90a8-c4e5ce623ec7.png)


After:
![image](https://cloud.githubusercontent.com/assets/1680372/8754132/46bca078-2c8f-11e5-9ebd-3c54d9c957fb.png)
